### PR TITLE
Create installer command

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -165,7 +165,7 @@ jobs:
           php ./source/tests/System/bin/Assert.php "str_contains(shell_exec('hyde --version --no-ansi'), 'HydePHP')"
           php ./source/tests/System/bin/Assert.php "str_contains(shell_exec('hyde --version'), 'Experimental Standalone')"
           php ./source/tests/System/bin/Assert.php "str_contains(shell_exec('hyde --no-ansi'), 'USAGE:  <command> [options] [arguments]')"
-        # TODO: Assert the new command is present, after we add it
+          php ./source/tests/System/bin/Assert.php "str_contains_all(shell_exec('hyde --no-ansi'), ['new', 'Create a new Hyde project.'])"
 
       - name: Test can run in anonymous project
         run: |

--- a/app/Commands/NewProjectCommand.php
+++ b/app/Commands/NewProjectCommand.php
@@ -60,6 +60,10 @@ class NewProjectCommand extends Command
             }
         })::getLogo());
 
+        if ($this->argument('name')) {
+            return $logo;
+        }
+
         return substr($logo, 0, strrpos($logo, "\n", -2));
     }
 }

--- a/app/Commands/NewProjectCommand.php
+++ b/app/Commands/NewProjectCommand.php
@@ -22,7 +22,7 @@ class NewProjectCommand extends Command
 
     public function handle(): void
     {
-        $name = $this->argument('name') ?? text('What is the name of your project?');
+        $name = $this->argument('name') ?? text('What is the name of your project?', required: 'Please provide a name for your project.');
 
         Process::command($this->getCommand($name))
             ->run(null, $this->bufferedOutput());

--- a/app/Commands/NewProjectCommand.php
+++ b/app/Commands/NewProjectCommand.php
@@ -32,7 +32,7 @@ class NewProjectCommand extends Command
 
     protected function getCommand(string $name): string
     {
-        return "composer create-project hyde/hyde {$name} --prefer-dist" . ($this->withAnsi() ? ' --ansi' : ' --no-ansi');
+        return sprintf("composer create-project hyde/hyde %s --prefer-dist%s", $name, $this->withAnsi() ? ' --ansi' : ' --no-ansi');
     }
 
     protected function withAnsi(): bool

--- a/app/Commands/NewProjectCommand.php
+++ b/app/Commands/NewProjectCommand.php
@@ -11,5 +11,9 @@ use Illuminate\Console\Command;
  */
 class NewProjectCommand extends Command
 {
-    //
+    /** @var string */
+    protected $signature = 'new {name : The name of the project}';
+
+    /** @var string */
+    protected $description = 'Create a new Hyde project.';
 }

--- a/app/Commands/NewProjectCommand.php
+++ b/app/Commands/NewProjectCommand.php
@@ -23,8 +23,6 @@ class NewProjectCommand extends Command
     {
         $name = $this->argument('name');
 
-        $this->info("Creating new Hyde project: {$name}");
-
         Process::command($this->getCommand($name))
             ->run(output: $this->bufferedOutput());
     }

--- a/app/Commands/NewProjectCommand.php
+++ b/app/Commands/NewProjectCommand.php
@@ -24,7 +24,7 @@ class NewProjectCommand extends Command
         $name = $this->argument('name');
 
         Process::command($this->getCommand($name))
-            ->run(output: $this->bufferedOutput());
+            ->run(null, $this->bufferedOutput());
 
         $this->newLine();
         $this->info('Project created successfully. Build something awesome!');

--- a/app/Commands/NewProjectCommand.php
+++ b/app/Commands/NewProjectCommand.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Commands;
 
 use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Process;
 
 /**
  * Creates a new Hyde project.
@@ -16,4 +17,14 @@ class NewProjectCommand extends Command
 
     /** @var string */
     protected $description = 'Create a new Hyde project.';
+
+    public function handle(): void
+    {
+        $name = $this->argument('name');
+
+        $this->info("Creating new Hyde project: {$name}");
+
+        Process::command("composer create-project hyde/hyde {$name} --prefer-dist")
+            ->run();
+    }
 }

--- a/app/Commands/NewProjectCommand.php
+++ b/app/Commands/NewProjectCommand.php
@@ -25,6 +25,9 @@ class NewProjectCommand extends Command
 
         Process::command($this->getCommand($name))
             ->run(output: $this->bufferedOutput());
+
+        $this->newLine();
+        $this->info('Project created successfully. Build something awesome!');
     }
 
     protected function getCommand(string $name): string

--- a/app/Commands/NewProjectCommand.php
+++ b/app/Commands/NewProjectCommand.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Commands;
+
+use Illuminate\Console\Command;
+
+/**
+ * Creates a new Hyde project.
+ */
+class NewProjectCommand extends Command
+{
+    //
+}

--- a/app/Commands/NewProjectCommand.php
+++ b/app/Commands/NewProjectCommand.php
@@ -24,9 +24,14 @@ class NewProjectCommand extends Command
 
         $this->info("Creating new Hyde project: {$name}");
 
-        Process::command("composer create-project hyde/hyde {$name} --prefer-dist")
+        Process::command($this->getCommand($name))
             ->run(output: function ($type, $buffer) {
                 $this->output->write($buffer);
             });
+    }
+
+    protected function getCommand(string $name): string
+    {
+        return "composer create-project hyde/hyde {$name} --prefer-dist";
     }
 }

--- a/app/Commands/NewProjectCommand.php
+++ b/app/Commands/NewProjectCommand.php
@@ -60,10 +60,11 @@ class NewProjectCommand extends Command
             }
         })::getLogo());
 
-        if ($this->argument('name')) {
-            return $logo;
+        if (! $this->argument('name')) {
+            // If we need to prompt for the name, we trim the empty lines from the logo, so it lays flat.
+            return substr($logo, 0, strrpos($logo, "\n", -2));
         }
 
-        return substr($logo, 0, strrpos($logo, "\n", -2));
+        return $logo;
     }
 }

--- a/app/Commands/NewProjectCommand.php
+++ b/app/Commands/NewProjectCommand.php
@@ -32,6 +32,11 @@ class NewProjectCommand extends Command
 
     protected function getCommand(string $name): string
     {
-        return "composer create-project hyde/hyde {$name} --prefer-dist";
+        return "composer create-project hyde/hyde {$name} --prefer-dist" . ($this->withAnsi() ? ' --ansi' : ' --no-ansi');
+    }
+
+    protected function withAnsi(): bool
+    {
+        return ! $this->option('no-ansi') || $this->option('ansi');
     }
 }

--- a/app/Commands/NewProjectCommand.php
+++ b/app/Commands/NewProjectCommand.php
@@ -32,7 +32,7 @@ class NewProjectCommand extends Command
 
     protected function getCommand(string $name): string
     {
-        return sprintf("composer create-project hyde/hyde %s --prefer-dist%s", $name, $this->withAnsi() ? ' --ansi' : ' --no-ansi');
+        return trim(sprintf('composer create-project hyde/hyde %s --prefer-dist %s', $name, $this->withAnsi() ? '--ansi' : '--no-ansi'));
     }
 
     protected function withAnsi(): bool

--- a/app/Commands/NewProjectCommand.php
+++ b/app/Commands/NewProjectCommand.php
@@ -25,6 +25,8 @@ class NewProjectCommand extends Command
         $this->info("Creating new Hyde project: {$name}");
 
         Process::command("composer create-project hyde/hyde {$name} --prefer-dist")
-            ->run();
+            ->run(output: function ($type, $buffer) {
+                $this->output->write($buffer);
+            });
     }
 }

--- a/app/Commands/NewProjectCommand.php
+++ b/app/Commands/NewProjectCommand.php
@@ -7,6 +7,7 @@ namespace App\Commands;
 use Closure;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Process;
+use function Laravel\Prompts\text;
 
 /**
  * Creates a new Hyde project.
@@ -14,14 +15,14 @@ use Illuminate\Support\Facades\Process;
 class NewProjectCommand extends Command
 {
     /** @var string */
-    protected $signature = 'new {name : The name of the project}';
+    protected $signature = 'new {name? : The name of the project}';
 
     /** @var string */
     protected $description = 'Create a new Hyde project.';
 
     public function handle(): void
     {
-        $name = $this->argument('name');
+        $name = $this->argument('name') ?? text('What is the name of your project?');
 
         Process::command($this->getCommand($name))
             ->run(null, $this->bufferedOutput());

--- a/app/Commands/NewProjectCommand.php
+++ b/app/Commands/NewProjectCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Commands;
 
+use Closure;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Process;
 
@@ -25,9 +26,7 @@ class NewProjectCommand extends Command
         $this->info("Creating new Hyde project: {$name}");
 
         Process::command($this->getCommand($name))
-            ->run(output: function ($type, $buffer) {
-                $this->output->write($buffer);
-            });
+            ->run(output: $this->bufferedOutput());
     }
 
     protected function getCommand(string $name): string
@@ -38,5 +37,12 @@ class NewProjectCommand extends Command
     protected function withAnsi(): bool
     {
         return ! $this->option('no-ansi') || $this->option('ansi');
+    }
+
+    protected function bufferedOutput(): Closure
+    {
+        return function (string $type, string $buffer): void {
+            $this->output->write($buffer);
+        };
     }
 }

--- a/app/Commands/NewProjectCommand.php
+++ b/app/Commands/NewProjectCommand.php
@@ -53,11 +53,13 @@ class NewProjectCommand extends Command
 
     private function getLogo(): string
     {
-        return trim((new class(app()) extends ConsoleServiceProvider {
+        $logo = trim((new class(app()) extends ConsoleServiceProvider {
             public static function getLogo(): string
             {
                 return self::logo();
             }
         })::getLogo());
+
+        return substr($logo, 0, strrpos($logo, "\n", -2));
     }
 }

--- a/app/Commands/NewProjectCommand.php
+++ b/app/Commands/NewProjectCommand.php
@@ -23,7 +23,7 @@ class NewProjectCommand extends Command
 
     public function handle(): void
     {
-        $this->output->write($this->getLogo());
+        $this->output->write($this->withAnsi() ? $this->getLogo() : 'Welcome to HydePHP!');
 
         $name = $this->argument('name') ?? text('What is the name of your project?', required: 'Please provide a name for your project.');
 

--- a/app/Commands/NewProjectCommand.php
+++ b/app/Commands/NewProjectCommand.php
@@ -7,6 +7,7 @@ namespace App\Commands;
 use Closure;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Process;
+use Hyde\Console\ConsoleServiceProvider;
 use function Laravel\Prompts\text;
 
 /**
@@ -22,6 +23,8 @@ class NewProjectCommand extends Command
 
     public function handle(): void
     {
+        $this->output->write($this->getLogo());
+
         $name = $this->argument('name') ?? text('What is the name of your project?', required: 'Please provide a name for your project.');
 
         Process::command($this->getCommand($name))
@@ -46,5 +49,15 @@ class NewProjectCommand extends Command
         return function (string $type, string $buffer): void {
             $this->output->write($buffer);
         };
+    }
+
+    private function getLogo(): string
+    {
+        return trim((new class(app()) extends ConsoleServiceProvider {
+            public static function getLogo(): string
+            {
+                return self::logo();
+            }
+        })::getLogo());
     }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -11,7 +11,9 @@ class AppServiceProvider extends ServiceProvider
      */
     public function register(): void
     {
-        //
+        $this->commands([
+            \App\Commands\NewProjectCommand::class,
+        ]);
     }
 
     /**

--- a/tests/Unit/NewProjectCommandTest.php
+++ b/tests/Unit/NewProjectCommandTest.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Foundation\Application;
+use Illuminate\Support\Facades\Process;
+use Illuminate\Contracts\Console\Kernel;
+
+function bootstrap(): Application
+{
+    $app = require __DIR__ . '/../../app/bootstrap.php';
+
+    $app->make(Kernel::class)->bootstrap();
+
+    return $app;
+}
+
+test('can create new project', function () {
+    $app = bootstrap();
+
+    Process::preventStrayProcesses();
+
+    Process::shouldReceive('command')->once()->with('composer create-project hyde/hyde test-project --prefer-dist --ansi')->andReturnSelf();
+
+    Process::shouldReceive('run')->once()->withArgs([null, Mockery::type(Closure::class)])->andReturnSelf();
+
+    $app->make(Kernel::class)->call('new', ['name' => 'test-project']);
+});


### PR DESCRIPTION
Creates a simplified version of [`Laravel@NewCommand.php`](https://github.com/laravel/installer/blob/master/src/NewCommand.php), to quickly create new HydePHP projects using the standalone.