### PR TITLE
Refactor to use custom application class instead of anonymous class

### DIFF
--- a/app/Application.php
+++ b/app/Application.php
@@ -12,7 +12,7 @@ class Application extends \Hyde\Foundation\Application
         return HYDE_TEMP_DIR . '/app/storage/framework/cache/packages.php';
     }
 
-    public function getNamespace()
+    public function getNamespace(): string
     {
         if (file_exists($this->basePath('composer.json'))) {
             return parent::getNamespace();

--- a/app/Application.php
+++ b/app/Application.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App;
+
+class Application
+{
+    //
+}

--- a/app/Application.php
+++ b/app/Application.php
@@ -4,7 +4,21 @@ declare(strict_types=1);
 
 namespace App;
 
-class Application
+class Application extends \Hyde\Foundation\Application
 {
-    //
+    public function getCachedPackagesPath(): string
+    {
+        // Since we have a custom path for the cache directory, we need to return it here.
+        return HYDE_TEMP_DIR . '/app/storage/framework/cache/packages.php';
+    }
+
+    public function getNamespace()
+    {
+        if (file_exists($this->basePath('composer.json'))) {
+            return parent::getNamespace();
+        }
+
+        // Adds a fallback so that the application can still run without a composer.json file
+        return 'App';
+    }
 }

--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -21,23 +21,7 @@ if (! defined('HYDE_TEMP_DIR')) {
 |
 */
 
-$app = new class(HYDE_WORKING_DIR) extends \Hyde\Foundation\Application {
-    public function getCachedPackagesPath(): string
-    {
-        // Since we have a custom path for the cache directory, we need to return it here.
-        return HYDE_TEMP_DIR . '/app/storage/framework/cache/packages.php';
-    }
-
-    public function getNamespace()
-    {
-        if (file_exists($this->basePath('composer.json'))) {
-            return parent::getNamespace();
-        }
-
-        // Adds a fallback so that the application can still run without a composer.json file
-        return 'App';
-    }
-};
+$app = new \App\Application(HYDE_WORKING_DIR);
 
 /*
 |--------------------------------------------------------------------------

--- a/tests/Unit/ApplicationTest.php
+++ b/tests/Unit/ApplicationTest.php
@@ -1,0 +1,19 @@
+<?php
+
+use App\Application;
+use Hyde\Foundation\Application as HydeApplication;
+
+const HYDE_WORKING_DIR = '/path/to/working/dir';
+const HYDE_TEMP_DIR = '/path/to/temp/dir';
+
+test('custom application extends Hyde application', function () {
+    expect(new Application())->toBeInstanceOf(HydeApplication::class);
+});
+
+it('uses custom cached packages path', function () {
+    expect((new Application())->getCachedPackagesPath())->toBe(HYDE_TEMP_DIR . '/app/storage/framework/cache/packages.php');
+});
+
+it('uses custom namespace', function () {
+    expect((new Application())->getNamespace())->toBe('App');
+});

--- a/tests/Unit/BootstrapTest.php
+++ b/tests/Unit/BootstrapTest.php
@@ -16,7 +16,8 @@ beforeEach(function () {
 });
 
 test('anonymous bootstrapper returns application', function () {
-    expect($this->app)->toBeInstanceOf(Application::class);
+    expect($this->app)->toBeInstanceOf(\App\Application::class)
+        ->and($this->app)->toBeInstanceOf(Application::class);
 });
 
 it('has correct base path', function () {


### PR DESCRIPTION
Refactor bootstrapper to use custom application class instead of anonymous class. Decouples code making it easier to manage and test.