### PR TITLE
Configure project details to support global Composer installation

### DIFF
--- a/box.json
+++ b/box.json
@@ -12,6 +12,7 @@
     "app/Commands/Internal"
   ],
   "exclude-composer-files": false,
+  "exclude-dev-files": false,
   "compression": "GZ",
   "compactors": [
     "KevinGH\\Box\\Compactor\\Php",

--- a/composer.json
+++ b/composer.json
@@ -25,10 +25,7 @@
         }
     ],
     "require": {
-        "php": "^8.1",
-        "hyde/framework": "dev-develop",
-        "hyde/realtime-compiler": "dev-improve-portability",
-        "laravel-zero/framework": "^10.0"
+        "php": "^8.1"
     },
     "autoload": {
         "psr-4": {
@@ -60,6 +57,9 @@
         "hyde"
     ],
     "require-dev": {
+        "hyde/framework": "dev-develop",
+        "hyde/realtime-compiler": "dev-improve-portability",
+        "laravel-zero/framework": "^10.0",
         "mockery/mockery": "^1.6",
         "pestphp/pest": "^2.26"
     }

--- a/composer.json
+++ b/composer.json
@@ -1,11 +1,12 @@
 {
-    "name": "hyde/hyde",
-    "description": "Static Site Generator to rapidly create Blogs, Documentation Sites, and more, using Markdown and Blade.",
+    "name": "hyde/cli",
+    "description": "Experimental Standalone Version of HydePHP - The Static Site Generator You've Been Waiting For",
     "keywords": [
         "framework",
         "hyde",
         "hyde framework",
         "hydephp",
+        "hydecli",
         "static site generator",
         "static site framework",
         "ssg"
@@ -14,8 +15,8 @@
     "type": "project",
     "license": "MIT",
     "support": {
-        "issues": "https://github.com/hydephp/hyde/issues",
-        "source": "https://github.com/hydephp/hyde"
+        "issues": "https://github.com/hydephp/cli/issues",
+        "source": "https://github.com/hydephp/cli"
     },
     "authors": [
         {

--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,7 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "bin": [
-        "hyde"
+        "builds/hyde"
     ],
     "require-dev": {
         "hyde/framework": "dev-develop",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d7e00666a1b24e35617ccd2183206558",
+    "content-hash": "816b0cafc4da990894022fbb10c073ba",
     "packages": [
         {
             "name": "brick/math",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "816b0cafc4da990894022fbb10c073ba",
+    "content-hash": "643b8a2ee924830694018123fb6597d4",
     "packages": [
         {
             "name": "brick/math",


### PR DESCRIPTION
Makes the necessary changes to the project configuration in order to allow global Composer installation through Packagist. Also updates the root `composer.json` to use `hyde/cli` as the package name, as that won in the [Twitter poll](https://twitter.com/CodeWithCaen/status/1731694039714459870).