### PR TITLE
Customize console describer summary class

### DIFF
--- a/app/Commands/Internal/Describer.php
+++ b/app/Commands/Internal/Describer.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Commands\Internal;
+
+use NunoMaduro\LaravelConsoleSummary\Describer as BaseDescriber;
+
+class Describer extends BaseDescriber
+{
+    //
+}

--- a/app/Commands/Internal/Describer.php
+++ b/app/Commands/Internal/Describer.php
@@ -8,5 +8,14 @@ use NunoMaduro\LaravelConsoleSummary\Describer as BaseDescriber;
 
 class Describer extends BaseDescriber
 {
-    //
+    protected static function sortCommandsInGroup(array &$commands): void
+    {
+        usort($commands, function ($a, $b) {
+            if  ($a->getName() === 'new') {
+                return -1;
+            }
+
+            return strcmp($a->getName(), $b->getName());
+        });
+    }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -4,8 +4,10 @@ namespace App\Providers;
 
 use App\Commands\NewProjectCommand;
 use App\Commands\ServeCommand;
+use App\Commands\Internal\Describer;
 use App\Commands\VendorPublishCommand;
 use Illuminate\Support\ServiceProvider;
+use NunoMaduro\LaravelConsoleSummary\Contracts\DescriberContract;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -32,5 +34,8 @@ class AppServiceProvider extends ServiceProvider
             ServeCommand::class,
             VendorPublishCommand::class,
         ]);
+
+        // Register custom Laravel summary command describer implementation.
+        $this->app->singleton(DescriberContract::class, Describer::class);
     }
 }


### PR DESCRIPTION
Fixes https://github.com/caendesilva/hyde-global/issues/7 assuming https://github.com/nunomaduro/laravel-console-summary/pull/20 is merged. The feature is gracefully handled to not do anything bad in the meantime, but will seamlessly work once/if the upstream PR is merged.